### PR TITLE
Disable composer timeout for serve script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,12 @@
         "php": ">=7.1.0",
         "getkirby/cms": "^3.0"
     },
+    "scripts": {
+        "start": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php -S localhost:8000 kirby/router.php"
+        ]
+    },
     "config": {
         "optimize-autoloader": true
     }


### PR DESCRIPTION
I've ran into timeouts some time ago with a similar serve script. I think a more robust solution would be to disable the timeout for the start script.

> The default value is 300 seconds (5 minutes).

https://getcomposer.org/doc/03-cli.md#composer-process-timeout

