### PR TITLE
Add .htaccess permissions policy to opt-out of FLoC

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -55,3 +55,8 @@ AddOutputFilterByType DEFLATE application/json
 AddOutputFilterByType DEFLATE application/javascript
 AddOutputFilterByType DEFLATE application/x-javascript
 </IfModule>
+
+<IfModule mod_headers.c>
+# Opt-out of Google Chrome's FLoC per default
+Header always set Permissions-Policy: interest-cohort=()
+</IfModule>


### PR DESCRIPTION
Opt-out of Google Chrome's FLoC per default to increase privacy in new Kirby installs.

As Kirby weights privacy with high priority based on its website, It should opt out of Google Chrome's FLoC per default.

More information about FLoC in the well described blog post by [Plausible Analytics](https://plausible.io/blog/google-floc) (I'm not affiliated with them. I just found this post describes it well).