### PR TITLE
Remove `title` from `site.yml`

### DIFF
--- a/site/blueprints/site.yml
+++ b/site/blueprints/site.yml
@@ -1,3 +1,2 @@
-title: Site
 preset: pages
 unlisted: true


### PR DESCRIPTION
To actually use `view.site` translation strings in the Panel.