### PR TITLE
Remove duplicate indent_style definition in EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,6 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-insert_final_newline = true
 
 [*.md]
 indent_size = 4


### PR DESCRIPTION
There's a duplicate `indent_style` definition in the `.editorconfig`. This PR removed one of them.