### PR TITLE
Bump Kirby version to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-    "getkirby/cms": "^4.0"
+    "getkirby/cms": "^5.0"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
This should no longer require Kirby v4.0, but Kirby v5.0 instead.